### PR TITLE
Clean up download.js

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -12,7 +12,7 @@ const timeout = 120000
 
 export default async function downloadNetfile({ agencyId, year }) {
     const downloadPageUrl = `https://public.netfile.com/pub2/Default.aspx?aid=${agencyId}`
-    const browser = await puppeteer.launch({ timeout })
+    const browser = await puppeteer.launch({ headless: "new", timeout })
     const page = await browser.newPage()
 
     async function goto() {
@@ -39,7 +39,7 @@ export default async function downloadNetfile({ agencyId, year }) {
     // downloading, let's just wait 5 seconds and see if
     // that works for now. shrug
     // const fileName = `${aid}-${year}.zip`
-    await page.waitForTimeout(7000)
+    await new Promise(resolve => setTimeout(resolve, 7000));
     await browser.close()
     return
 }

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -12,7 +12,7 @@ const timeout = 120000
 
 export default async function downloadNetfile({ agencyId, year }) {
     const downloadPageUrl = `https://public.netfile.com/pub2/Default.aspx?aid=${agencyId}`
-    const browser = await puppeteer.launch({ headless: "new", timeout })
+    const browser = await puppeteer.launch({ timeout })
     const page = await browser.newPage()
 
     async function goto() {

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -41,5 +41,4 @@ export default async function downloadNetfile({ agencyId, year }) {
     // const fileName = `${aid}-${year}.zip`
     await new Promise(resolve => setTimeout(resolve, 7000));
     await browser.close()
-    return
 }


### PR DESCRIPTION
Page.waitForTimeout() is deprecated. https://pptr.dev/api/puppeteer.page.waitfortimeout 

Specify "headless: new" to suppress warning when running script. 
**New headless info:** https://developer.chrome.com/articles/new-headless/ 
**Description of warning:** https://github.com/code4sac/sacramento-campaign-finance/pull/5