### PR TITLE
Make homepage work better on phones

### DIFF
--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -4,9 +4,9 @@
 
 <style>
   footer {
-		bottom: 0;
 		font-size: 14px;
 		line-height: 18px;
+		margin-top: 1rem;
 		margin-bottom: 1rem;
 		text-align: center;
 		width: 100%;

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -1,18 +1,18 @@
 <script>
-    import { IconBuildingSkyscraper, IconWorld } from "@tabler/icons-svelte";
-    import { writable } from "svelte/store";
+    // import { IconBuildingSkyscraper, IconWorld } from "@tabler/icons-svelte";
+    // import { writable } from "svelte/store";
 
-    const langs = [
-        {
-            id: "en",
-            label: "English",
-        },
-        {
-            id: "es",
-            label: "Español",
-        },
-    ];
-    const lang = writable("en");
+    // const langs = [
+    //     {
+    //         id: "en",
+    //         label: "English",
+    //     },
+    //     {
+    //         id: "es",
+    //         label: "Español",
+    //     },
+    // ];
+    // const lang = writable("en");
 </script>
 
 <nav>
@@ -31,8 +31,7 @@
             <a href="/body/sac-county" target="_self">Board of Supervisors</a>
         </li>
     </ul>
-    <div class="dropdown-container">
-        <!-- location toggle -->
+    <!-- <div class="dropdown-container">
         <div class="dropdown">
             <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown"
                 ><IconBuildingSkyscraper /> Sacramento, CA</a
@@ -41,7 +40,6 @@
                 <a class="dropdown-item" href="#">Sacramento, CA</a>
             </div>
         </div>
-        <!-- language toggle -->
         <div class="dropdown">
             <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown"
                 ><IconWorld /> English</a
@@ -50,14 +48,7 @@
                 <a class="dropdown-item" href="#">English</a>
             </div>
         </div>
-    </div>
-    <div class="select-container">
-        <!-- <select bind:value={$lang}>
-      {#each langs as l}
-        <option value={l.id}>{l.label}</option>
-      {/each}
-    </select> -->
-    </div>
+    </div> -->
 </nav>
 
 <style lang="scss">

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -15,113 +15,57 @@
     // const lang = writable("en");
 </script>
 
-<nav>
-    <h1 class="nav-logo">Sacramento Campaign Cash</h1>
-    <ul>
-        <li>
-            <a href="/">Home</a>
-        </li>
-        <li>
-            <a href="/election/2024" target="_self">Upcoming election</a>
-        </li>
-        <li>
-            <a href="/body/sac-city" target="_self">City Council</a>
-        </li>
-        <li>
-            <a href="/body/sac-county" target="_self">Board of Supervisors</a>
-        </li>
-    </ul>
-    <!-- <div class="dropdown-container">
-        <div class="dropdown">
-            <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown"
-                ><IconBuildingSkyscraper /> Sacramento, CA</a
-            >
-            <div class="dropdown-menu">
-                <a class="dropdown-item" href="#">Sacramento, CA</a>
-            </div>
+<nav class="navbar navbar-expand-lg">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">Sacramento Campaign Cash</a>
+        <div class="navbar-collapse">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item">
+                    <a class="nav-link" href="/election/2024" target="_self">Upcoming election</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/body/sac-city" target="_self">City Council</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/body/sac-county" target="_self">Board of Supervisors</a>
+                </li>
+            </ul>
         </div>
-        <div class="dropdown">
-            <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown"
-                ><IconWorld /> English</a
-            >
-            <div class="dropdown-menu">
-                <a class="dropdown-item" href="#">English</a>
+    </div>
+        <!-- <div class="dropdown-container">
+            <div class="dropdown">
+                <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown"
+                    ><IconBuildingSkyscraper /> Sacramento, CA</a
+                >
+                <div class="dropdown-menu">
+                    <a class="dropdown-item" href="#">Sacramento, CA</a>
+                </div>
             </div>
-        </div>
-    </div> -->
+            <div class="dropdown">
+                <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown"
+                    ><IconWorld /> English</a
+                >
+                <div class="dropdown-menu">
+                    <a class="dropdown-item" href="#">English</a>
+                </div>
+            </div>
+        </div> -->
 </nav>
 
 <style lang="scss">
-    nav {
-        // display: grid;
-        // grid-template-columns: 150px 1fr 40%;
-        display: flex;
-        align-items: center;
-        background: #fff;
-        padding: 10px 40px 10px 40px;
-        color: #1e1e1e;
-        font-family: Inter;
-        font-size: 14px;
-        font-style: normal;
-        font-weight: 500;
-        line-height: normal;
-        width: 100%;
-    }
-    .nav-logo {
-        color: #1e1e1e;
-        font-family: Inter;
-        font-size: 16px;
-        font-style: normal;
-        font-weight: 700;
-        line-height: normal;
-    }
-    .dropdown-container {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
-    h1 {
-        grid-column: 1 / 2;
-        font-size: 1rem;
-        line-height: 1.2rem;
-        max-width: 150px;
-        width: 150px;
-    }
-    ul {
-        display: flex;
-        // grid-column: 2/3;
-        justify-content: left;
-        align-items: center;
-        list-style-type: none;
-        padding: 10;
-        width: 100%;
-        gap: 30px;
-    }
-    // ideas for getting underline to appear
-    // li {
-    //     // padding-bottom: px;
+    // .dropdown-container {
+    //     display: flex;
+    //     justify-content: center;
+    //     align-items: center;
     // }
-    // li:hover {
-    //     border-bottom: #1e1e1e;
-    // }
-    // a {
-    //     padding-bottom: 10px;
-    //     text-decoration: none;
-    // }
-    // a:hover {
-    //     border-color: black;
-    //     border-bottom: 5px;
-    // }
-    a:hover {
-        color: #0054a6;
-    }
 
-    .select-container {
-        display: flex;
-        justify-content: flex-end;
-        grid-column: 3;
-    }
-    .dropdown-container {
-        gap: 30px;
-    }
+
+    // .select-container {
+    //     display: flex;
+    //     justify-content: flex-end;
+    //     grid-column: 3;
+    // }
+    // .dropdown-container {
+    //     gap: 30px;
+    // }
 </style>

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -11,16 +11,41 @@ export function load() {
         }).flat()
         const matching = data.filter(d => legislatorsCommitteeIds.includes(d.fppcId))
         const total = sum(matching, d => d.amount)
+        let offices = ['Mayor', 'City councilmembers']
+
+        if (body === 'sac-county') {
+            offices = ['Supervisors']
+        }
         return {
             body,
+            href: `/body/${body}`,
             name,
             total,
-            officials: []
+            offices,
         }
     })
 
+    const upcomingElection = config.elections.find(d => d.year === 2024)
+    const allElectionCommitteeIds = upcomingElection.contests.map(contest => {
+        const candidateIds = contest.candidates.map(d => d.committee.id)
+        return candidateIds
+    }).flat()
+
+    const electionData = data.filter(d => {
+        return allElectionCommitteeIds.includes(d.fppcId)
+    })
+    const electionTotal = sum(electionData, d => d.amount)
+
+    const election = {
+        body: '',
+        href: `/election/2024`,
+        name: 'Upcoming election',
+        total: electionTotal,
+        offices: ['Mayor', 'City councilmembers (D2, D4, D6, D8)']
+    }
+
     return {
         generated,
-        totals
+        totals: [election, ...totals]
     }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,6 @@
 <script>
     import { sum } from "d3-array";
-    import { writable } from "svelte/store";
-    import config from "$lib/../../config.js";
     import { formatDollar, formatGenerated } from "$lib/format.js";
-    import Legislator from "$lib/Legislator.svelte";
     import OfficialsCard from "$lib/OfficialsCard.svelte";
     import { IconArrowNarrowRight } from "@tabler/icons-svelte";
 
@@ -12,14 +9,6 @@
     // totals raised
     const { generated, totals } = data;
     const total = sum(totals, (d) => d.total);
-
-    const blocks = totals.map((b) => {
-        return {
-            label: b.name,
-            href: `/body/${b.body}`,
-            value: b.total,
-        };
-    });
 
     //browse officials data, manually putting info here until automated
     //links should go to each official's page once theyre created
@@ -70,35 +59,58 @@
 </script>
 
 <div class="hero-tagline">
-    <h1 class="tagline">Campaign Finance Data<br /> in Sacramento</h1>
-</div>
-<div class="hero">
-    <!-- total amount raised -->
-    <div class="total-raised-container">
-        <h2 class="total-raised-amount">
-            {formatDollar(total)}
-        </h2>
-        <p class="total-raised-label">
-            Total amount reported by local officials
-        </p>
+    <div class="container">
+        <h1 class="tagline">Campaign Finance Data for Sacramento City and County</h1>
+        <p>Regularly updated campaign finance data for elected officials in the City and County of Sacramento, California. We don't manipulate the data except to normalize some name spellings so that our aggregations can be more accurate. <a href="#about-the-data">Learn more about the data.</a></p>
+        <p>The last data update happened on {formatGenerated(generated)}.</p>
     </div>
-    <!-- council/baord block container -->
-    <div class="blocks-container">
-        {#each blocks as block}
-            <div class="block">
-                <div class="block-title">{block.label}</div>
-                <div class="amount">{formatDollar(block.value)}</div>
-                <div class="amount-label">Raised</div>
-                <div class="block-link">
-                    <a href={block.href} class="btn btn-primary"
-                        >Learn More <IconArrowNarrowRight /></a
-                    >
+</div>
+
+<div class="container">
+    <div class="row row-cols-1 row-cols-md-3 mb-3 mt-3 text-center">
+        {#each totals as block}
+            <div class="col">
+                <div class="card mb-4 rounded-3 shadow-sm">
+                    <div class="card-header py-3">
+                        <h3 class="my-0">
+                            {block.name}
+                        </h3>
+                    </div>
+                    <div class="card-body">
+                    <h1 class="card-title pricing-card-title">{formatDollar(block.total)}</h1>
+                    <ul class="list-unstyled mt-3 mb-4">
+                        {#each block.offices as office}
+                            <li>{office}</li>
+                        {/each}
+                    </ul>
+                    <a href={block.href} class="btn btn-primary">
+                        Learn More <IconArrowNarrowRight />
+                        </a>
+                    </div>
+                </div>
+            </div>
+        {/each}
+    </div>
+</div>
+
+
+<!-- <div class="hero">
+    <div class="container">
+        
+            <div class="card">
+                <div class="card-body">
+                    <div class="block-title"></div>
+                    <div class="amount">{formatDollar(block.value)}</div>
+                    <div class="amount-label">Raised</div>
+                    <div class="block-link">
+                        
+                    </div>
                 </div>
             </div>
         {/each}
         <p>Last updated on {formatGenerated(generated)}</p>
     </div>
-</div>
+</div> -->
 <!-- browse by official boxes -->
 <div class="browse-container">
     <div class="browse-tagline">
@@ -136,7 +148,7 @@
     </div>
 
     <div class="about-container">
-        <h2 id="about">About the data</h2>
+        <h2 id="about-the-data">About the data</h2>
       
         <h3>Where does the data come from?</h3>
         <p>The data is scraped from <a href="https://public.netfile.com/pub2/?aid=SAC">the city's financial reports site</a> and <a href="https://public.netfile.com/pub2/?aid=SCO">the county's site</a>. The last time scrape was on {formatGenerated(generated)} California time. The scraper code is <a href="https://github.com/code4sac/sacramento-campaign-finance/blob/main/scripts/index.js">here</a>.</p>
@@ -172,43 +184,18 @@
     //     height: 100%;
     //     margin: 0;
     // }
-    .hero {
-        --column-gutter: 1rem;
-        display: grid;
-        grid-template-columns:
-            var(--column-gutter) 2fr var(--column-gutter) 1fr var(
-                --column-gutter
-            )
-            1fr var(--column-gutter);
-        grid-template-rows: var(--column-gutter) 1fr var(--column-gutter) 1fr var(
-                --column-gutter
-            );
-        min-height: 50vh;
-        padding-top: 2rem;
-        padding-bottom: 2rem;
-    }
-    .hero-tagline {
-        padding-left: 40px;
-        padding-top: 80px;
-        padding-bottom: 35px;
-        background: #09447c;
-        color: #fff;
-        width: 100%;
-        position: relative;
-    }
-
-    .tagline {
-        color: #fff;
-        font-family: Inter;
-        font-size: 36px;
-        font-style: normal;
-        font-weight: 600;
-        line-height: normal;
-        grid-column: 2/2;
-        grid-row: 2/2;
-        line-height: 1.1em;
-        margin: 0;
-    }
+    // .tagline {
+    //     color: #fff;
+    //     font-family: Inter;
+    //     font-size: 36px;
+    //     font-style: normal;
+    //     font-weight: 600;
+    //     line-height: normal;
+    //     grid-column: 2/2;
+    //     grid-row: 2/2;
+    //     line-height: 1.1em;
+    //     margin: 0;
+    // }
 
     .total-raised-container {
         // border: 1px solid white;


### PR DESCRIPTION
I adjusted the `<Nav />` bar and the homepage to not feel so broken on mobile phones. In doing this I slightly changed the design with the largest change being to remove the total amount in the system and instead make a block to correspond with each item in the navigation: upcoming election, city, and county.

When possible, I'm using Bootstrap classes to design elements, even if they differ slightly from the wire frame, so that we can use Bootstrap's documentation as our documentation as much as possible.

I think this should close out #24 and #31 