### PR TITLE
Show committee list on own line for legislator datagrid

### DIFF
--- a/src/lib/Legislator.svelte
+++ b/src/lib/Legislator.svelte
@@ -26,15 +26,15 @@
 <div class="legislator card col-sm-8">
   <div class="card-body">
     <div class="datagrid">
-      <div class="datagrid-item">
+      <div class="datagrid-item name-grid-item">
         <div class="datagrid-title">Name</div>
         <div class="datagrid-content">{name}</div>
       </div>
-      <div class="datagrid-item">
+      <div class="datagrid-item total-received-grid-item">
         <div class="datagrid-title">Total received</div>
         <div class="datagrid-content">${total.toLocaleString("en-US")}</div>
       </div>
-      <div class="datagrid-item">
+      <div class="datagrid-item committees-grid-item">
         <div class="datagrid-title">Committees</div>
         <div class="datagrid-content">
           <ul class="committees">
@@ -130,8 +130,11 @@
   }
 
   .committees {
-    list-style-type: none;
-    padding-left: 0;
+    padding-left: .8rem;
+  }
+
+  .committees-grid-item {
+    grid-column: 1;
   }
 
   .contributors-grid-item {


### PR DESCRIPTION
This changes the data grid in the `<Legislator />` component to always show the list of committees used for the data are shown on it's own line.

Before, notice the "Committees" information is cut off:
<img width="1453" alt="Screenshot 2023-10-15 at 2 59 30 PM" src="https://github.com/code4sac/sacramento-campaign-finance/assets/780941/f271a97e-4007-425b-8cb8-81180f4bd069">

After:
<img width="1453" alt="Screenshot 2023-10-15 at 3 04 51 PM" src="https://github.com/code4sac/sacramento-campaign-finance/assets/780941/d0adcf5e-6b69-42fc-ba07-f26223e513c0">
