### PR TITLE
Make official cards on homepage link to the proper section on the legislative body page

### DIFF
--- a/src/lib/Legislator.svelte
+++ b/src/lib/Legislator.svelte
@@ -1,6 +1,7 @@
 <script>
   import { orderBy } from 'lodash'
   import { sum } from "d3-array";
+  import { formatLegislatorAnchorId } from '$lib/format'
   import Contributors from "./Contributors.svelte";
   export let name = "";
   export let title = "";
@@ -20,7 +21,9 @@
 </script>
 
 <div class="hr-text">
-  {title}
+  <a id={formatLegislatorAnchorId(`${title}`)}>
+    {title}
+  </a>
 </div>
 
 <div class="legislator card col-sm-8">

--- a/src/lib/OfficialsCard.svelte
+++ b/src/lib/OfficialsCard.svelte
@@ -1,18 +1,15 @@
 <script>
+    export let link = "";
     export let name = "";
     export let title = "";
 </script>
 
-<!-- <div class="card officials-card">
-    <h3 class="card-title">{name}</h3>
-    <div class="card-secondary">
-        <p class="title">{title}</p>
-    </div>
-</div> -->
 <div class=" officials-card">
     <div class="">
-        <h3 class="headings">{name}</h3>
-        <p class="title">{title}</p>
+        <a href={link}>
+            <h3 class="headings">{name}</h3>
+            <p class="title">{title}</p>
+        </a>
     </div>
 </div>
 

--- a/src/lib/OfficialsCard.svelte
+++ b/src/lib/OfficialsCard.svelte
@@ -6,7 +6,7 @@
 
 <div class=" officials-card">
     <div class="">
-        <a href={link}>
+        <a href={link} style="width: fit-content;">
             <h3 class="headings">{name}</h3>
             <p class="title">{title}</p>
         </a>

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,4 +1,6 @@
+import { kebabCase } from 'lodash'
 import { timeFormat } from 'd3-time-format'
+
 export function formatDollar(number) {
     const floor = Math.floor(number)
     return `$${floor.toLocaleString('en-US')}`
@@ -8,4 +10,8 @@ export function formatGenerated(generated) {
     const fmt = timeFormat('%B %d, %Y at %I:%M %p')
     const d = new Date(generated)
     return fmt(d)
+}
+
+export function formatLegislatorAnchorId(str) {
+    return kebabCase(str.toLowerCase())
 }

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,4 +1,4 @@
-import { kebabCase } from 'lodash'
+import _ from 'lodash'
 import { timeFormat } from 'd3-time-format'
 
 export function formatDollar(number) {
@@ -13,5 +13,5 @@ export function formatGenerated(generated) {
 }
 
 export function formatLegislatorAnchorId(str) {
-    return kebabCase(str.toLowerCase())
+    return _.kebabCase(str.toLowerCase())
 }

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -2,6 +2,7 @@ import { sum } from 'd3-array'
 
 import config from '$lib/../../config.js'
 import { data, generated } from '$lib/data.json'
+import { formatLegislatorAnchorId } from '$lib/format'
 
 export function load() {
     const totals = config.bodies.map(b => {
@@ -19,8 +20,23 @@ export function load() {
         }
     })
 
+    const officials = config.bodies.map(d => {
+        const { body, legislators } = d
+        return legislators.map(l => {
+            const { name: legislatorName, title } = l
+            const encoded = formatLegislatorAnchorId(title)
+
+            return {
+                name: legislatorName,
+                title,
+                link: `/body/${body}#${encoded}`
+            }
+        })
+    }).flat()
+
     return {
         generated,
+        officials,
         totals
     }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,16 +1,14 @@
 <script>
     import { sum } from "d3-array";
     import { writable } from "svelte/store";
-    import config from "$lib/../../config.js";
-    import { formatDollar, formatGenerated } from "$lib/format.js";
-    import Legislator from "$lib/Legislator.svelte";
+    import { formatDollar, formatGenerated, formatLegislatorAnchorId } from "$lib/format.js";
     import OfficialsCard from "$lib/OfficialsCard.svelte";
     import { IconArrowNarrowRight } from "@tabler/icons-svelte";
 
     export let data = {};
 
     // totals raised
-    const { generated, totals } = data;
+    const { generated, officials, totals } = data;
     const total = sum(totals, (d) => d.total);
 
     const blocks = totals.map((b) => {
@@ -21,48 +19,19 @@
         };
     });
 
-    //browse officials data, manually putting info here until automated
-    //links should go to each official's page once theyre created
-    //This data should really go into another file,
-    export const ccData = [
-        { name: "Darrell Steinberg", title: "Mayor", link: "" },
-        { name: "Lisa Kaplan", title: "City Council, District 1", link: "" },
-        { name: "Sean Loloee", title: "City Council, District 2", link: "" },
-        {
-            name: "Karina Talamantes",
-            title: "City Council, District 3",
-            link: "",
-        },
-        {
-            name: "Katie Valenzuela",
-            title: "City Council, District 4",
-            link: "",
-        },
-        { name: "Caity Maple", title: "City Council, District 5", link: "" },
-        { name: "Eric Guerra", title: "City Council, District 6", link: "" },
-        { name: "Rick Jennings", title: "City Council, District 7", link: "" },
-        { name: "Mai Vang", title: "City Council, District 8", link: "" },
-    ];
 
-    export const bosData = [
-        { name: "Phil Sterna", title: "Supervisor, District 1", link: "" },
-        { name: "Patrick Kennedy", title: "Supervisor, District 2", link: "" },
-        { name: "Rich Desmond", title: "Supervisor, District 3", link: "" },
-        { name: "Sue Frost", title: "Supervisor, District 3", link: "" },
-        { name: "Pat Hume", title: "Supervisor, District 4", link: "" },
-    ];
-    let officialsData = [];
+    const officialsData = writable(officials);
     let officialDrop = "";
     function dropdownData(num) {
         if (num === 2) {
             officialDrop = "City Council";
-            officialsData = ccData;
+            $officialsData = officials.filter(d => d.link.startsWith('/body/sac-city'));
         } else if (num === 1) {
             officialDrop = "Board of Supervisors";
-            officialsData = bosData;
+            $officialsData = officials.filter(d => d.link.startsWith('/body/sac-county'));
         } else {
             officialDrop = "All Officials";
-            officialsData = ccData.concat(bosData);
+            $officialsData = officials;
         }
     }
     //defaults data to show all officials
@@ -103,10 +72,11 @@
 <div class="browse-container">
     <div class="browse-tagline">
         <h1>Browse by Official</h1>
+
         <div class="dropdown browse-dropdown">
-            <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown"
-                >{officialDrop}</a
-            >
+            <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+                {officialDrop}
+            </a>
             <div class="dropdown-menu">
                 <!-- can have both options OR state manage which option to
                 show depending on what's currently selected -->
@@ -127,10 +97,12 @@
                 >
             </div>
         </div>
+
+
     </div>
     <!-- blocks begin -->
     <div class="officials-container">
-        {#each officialsData as card}
+        {#each $officialsData as card}
             <OfficialsCard {...card} />
         {/each}
     </div>

--- a/src/routes/body/[bodyId]/+page.svelte
+++ b/src/routes/body/[bodyId]/+page.svelte
@@ -1,6 +1,6 @@
 <script>
     import { sum } from "d3-array";
-    import { formatDollar, formatGenerated } from "$lib/format";
+    import { formatDollar, formatGenerated, formatLegislatorAnchorId } from "$lib/format";
     import Legislator from "$lib/Legislator.svelte";
 
     export let data = {};


### PR DESCRIPTION
Right now the elected official cards just show who is in office but don't provide any detailed information about them. So I made them links to specific parts of the legislative body page - if you click on Mai Vang you'll go to the bottom of the city council page because she represents district 8.

I also used the configuration file to generate this information instead of having it in the relevant `+page.svelte` file so that everything that has to do with people (candidates or legislators) comes from the same place (`config.js`).