### PR TITLE
Change scraper year to 2024

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -15,7 +15,7 @@ console.log(`Starting at ${startTime}`);
 config.bodies.forEach((site) => {
     const { name: agencyName, vendorId: agencyId } = site;
     queue.add(async () => {
-        const year = '2023';
+        const year = '2024';
         const opts = { agencyName, agencyId, year };
 
         const f = `${agencyName} (${agencyId} - ${year})`;

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import Queue from 'p-queue';
 
-const years = [2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023];
+const years = [2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024];
 const schedules = ['schedule-a', 'schedule-c'];
 
 export default async function load() {


### PR DESCRIPTION
The scraper only checks for one year at a time to reduce the amount of time it takes to scrape, this changes it to check for 2024.

In the future, we could probably just have the script use the current year and that way the scraper can just run. Maybe?